### PR TITLE
RNDA-197 Missing type. Changed the Makefile to display all the errors…

### DIFF
--- a/sys/compat/linuxkpi/dummy/include/openbsd/net80211/openbsd_if_ether.h
+++ b/sys/compat/linuxkpi/dummy/include/openbsd/net80211/openbsd_if_ether.h
@@ -32,8 +32,8 @@
  *	@(#)if_ether.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _NETINET_IF_ETHER_H_
-#define _NETINET_IF_ETHER_H_
+#ifndef _OPENBSD_IF_ETHER_H_
+#define _OPENBSD_IF_ETHER_H_
 
 /*
  * Some basic Ethernet constants.
@@ -105,7 +105,7 @@ struct  ether_vlan_header {
 
 #define EVL_ENCAPLEN    4       /* length in octets of encapsulation */
 
-#include <net/ethertypes.h>
+//#include <net/ethertypes.h>
 
 #define	ETHER_IS_MULTICAST(addr) (*(addr) & 0x01) /* is address mcast/bcast? */
 #define	ETHER_IS_BROADCAST(addr) \

--- a/sys/dev/athn/headers/athnvar.h
+++ b/sys/dev/athn/headers/athnvar.h
@@ -18,6 +18,7 @@
 
 #include <openbsd/openbsd_queue.h>
 #include "../../../../crypto/openssh/openbsd-compat/sys-queue.h"
+#include <openbsd_device.h>
 
 #define NBPFILTER 0
 

--- a/sys/dev/athn/if_athn_usb.c
+++ b/sys/dev/athn/if_athn_usb.c
@@ -49,8 +49,9 @@
 #include <net/if_var.h>
 // #include <net/if_types.h>
 
+#include <net/if_arp.h>
 #include <netinet/in.h>
-#include <netinet/if_ether.h>
+//#include <netinet/if_ether.h>
 
 #include <openbsd/net80211/ieee80211_var.h>
 #include <openbsd/net80211/ieee80211_amrr.h>

--- a/sys/modules/usb/athn/Makefile
+++ b/sys/modules/usb/athn/Makefile
@@ -16,12 +16,15 @@ SRCS+=  opt_inet.h opt_inet6.h opt_route.h opt_netlink.h
 
 SRCS+=	${LINUXKPI_GENSRCS}
 
+CFLAGS+=        -ferror-limit=0
 CFLAGS+=	${LINUXKPI_INCLUDES}
 CFLAGS+=	-I${INCDIR}
 CFLAGS+= 	-I${SRCTOP}/sys/dev/athn/headers
+CFLAGS+=	-I${SRCTOP}/sys/compat/linuxkpi/dummy/include/openbsd
 # CFLAGS+= 	-I${SRCTOP}/sys/dev/athn/include/amd64
 # CFLAGS+= 	-I${SRCTOP}/sys/dev/athn/include/sys
 # CFLAGS+= 	-I${SRCTOP}/sys/dev/athn/include/net80211
+
 
 CWARNFLAGS+=	${NO_WUNUSED_BUT_SET_VARIABLE}
 CWARNFLAGS+=	${NO_WUNUSED_PARAMETER}

--- a/sys/netinet/if_ether.h
+++ b/sys/netinet/if_ether.h
@@ -35,7 +35,7 @@
 #ifndef _NETINET_IF_ETHER_H_
 #define _NETINET_IF_ETHER_H_
 
-#include <net/ethernet.h>
+//#include <net/ethernet.h>
 #include <net/if_arp.h>
 
 /*

--- a/sys/netinet/if_ether.h
+++ b/sys/netinet/if_ether.h
@@ -35,7 +35,7 @@
 #ifndef _NETINET_IF_ETHER_H_
 #define _NETINET_IF_ETHER_H_
 
-//#include <net/ethernet.h>
+#include <net/ethernet.h>
 #include <net/if_arp.h>
 
 /*


### PR DESCRIPTION
In addition, the patch fixes (purely by chance) two additional errors :
implicit declaration of "config_mountroot" (RNDA-199) and "loadfirmware" .
Changed Makefile to display all the errors as well.
Redundant headers where only commented out to keep with the practice of the predecessors (that way, it might be easier to follow the changes for the time being).