### PR TITLE
RNDA-208 Missing member named in 'struct ifnet'

### DIFF
--- a/sys/dev/athn/if_athn_usb.c
+++ b/sys/dev/athn/if_athn_usb.c
@@ -2118,7 +2118,6 @@ athn_usb_rx_frame(struct athn_usb_softc *usc, struct mbuf *m,
 	if (rs->rs_status != 0) {
 		if (rs->rs_status & AR_RXS_RXERR_DECRYPT)
 			ic->ic_stats.is_ccmp_dec_errs++;
-		ifp->if_ierrors++;
 		goto skip;
 	}
 	m_adj(m, sizeof(*rs));	/* Strip Rx status. */
@@ -2157,7 +2156,6 @@ athn_usb_rx_frame(struct athn_usb_softc *usc, struct mbuf *m,
 	    (IEEE80211_IS_MULTICAST(wh->i_addr1) &&
 	    ni->ni_rsngroupcipher == IEEE80211_CIPHER_CCMP))) {
 		if (ar5008_ccmp_decap(sc, m, ni) != 0) {
-			ifp->if_ierrors++;
 			ieee80211_release_node(ic, ni);
 			splx(s);
 			goto skip;
@@ -2252,9 +2250,6 @@ athn_usb_rxeof(struct usbd_xfer *xfer, void *priv,
 			}
 		} else	/* Drop frames larger than MCLBYTES. */
 			m = NULL;
-
-		if (m == NULL)
-			ifp->if_ierrors++;
 
 		/*
 		 * NB: m can be NULL, in which case the next pktlen bytes

--- a/sys/dev/athn/if_athn_usb.c
+++ b/sys/dev/athn/if_athn_usb.c
@@ -2504,7 +2504,6 @@ athn_usb_start(struct ifnet *ifp)
 		}
 
 		sc->sc_tx_timer = 5;
-		ifp->if_timer = 1;
 	}
 }
 
@@ -2513,8 +2512,6 @@ athn_usb_watchdog(struct ifnet *ifp)
 {
 	struct athn_softc *sc = ifp->if_softc;
 
-	ifp->if_timer = 0;
-
 	if (sc->sc_tx_timer > 0) {
 		if (--sc->sc_tx_timer == 0) {
 			printf("%s: device timeout\n", sc->sc_dev.dv_xname);
@@ -2522,7 +2519,6 @@ athn_usb_watchdog(struct ifnet *ifp)
 			ifp->if_oerrors++;
 			return;
 		}
-		ifp->if_timer = 1;
 	}
 	ieee80211_watchdog(ifp);
 }
@@ -2751,7 +2747,6 @@ athn_usb_stop(struct ifnet *ifp)
 	int s;
 
 	sc->sc_tx_timer = 0;
-	ifp->if_timer = 0;
 	ifp->if_flags &= ~IFF_RUNNING;
 	ifq_clr_oactive(&ifp->if_snd);
 

--- a/sys/dev/athn/if_athn_usb.c
+++ b/sys/dev/athn/if_athn_usb.c
@@ -2304,7 +2304,6 @@ athn_usb_txeof(struct usbd_xfer *xfer, void *priv,
 		DPRINTF(("TX status=%d\n", status));
 		if (status == USBD_STALLED)
 			usbd_clear_endpoint_stall_async(usc->tx_data_pipe);
-		ifp->if_oerrors++;
 		splx(s);
 		/* XXX Why return? */
 		return;
@@ -2499,7 +2498,6 @@ athn_usb_start(struct ifnet *ifp)
 #endif
 		if (athn_usb_tx(sc, m, ni) != 0) {
 			ieee80211_release_node(ic, ni);
-			ifp->if_oerrors++;
 			continue;
 		}
 
@@ -2516,7 +2514,6 @@ athn_usb_watchdog(struct ifnet *ifp)
 		if (--sc->sc_tx_timer == 0) {
 			printf("%s: device timeout\n", sc->sc_dev.dv_xname);
 			/* athn_usb_init(ifp); XXX needs a process context! */
-			ifp->if_oerrors++;
 			return;
 		}
 	}

--- a/sys/dev/athn/if_athn_usb.c
+++ b/sys/dev/athn/if_athn_usb.c
@@ -2612,7 +2612,7 @@ athn_usb_init(struct ifnet *ifp)
 	extc = NULL;
 
 	/* In case a new MAC address has been configured. */
-	IEEE80211_ADDR_COPY(ic->ic_myaddr, LLADDR(ifp->if_sadl));
+	IEEE80211_ADDR_COPY(ic->ic_myaddr, IF_LLADDR(ifp));
 
 	error = athn_set_power_awake(sc);
 	if (error != 0)


### PR DESCRIPTION
Remove if_ierrors incrementation.
This is OpenBSD internal variable to collect statistics. It does not exist in FreeBSD.