### PR TITLE
RNDA-212 incompatible pointer types passing 'struct mbuf_list *'

### DIFF
--- a/sys/dev/athn/if_athn_usb.c
+++ b/sys/dev/athn/if_athn_usb.c
@@ -2281,7 +2281,7 @@ athn_usb_rxeof(struct usbd_xfer *xfer, void *priv,
 		buf += off;
 		len -= off;
 	}
-	if_input(ifp, &ml);
+	if_input(ifp, m);
 
  resubmit:
 	/* Setup a new transfer. */


### PR DESCRIPTION
Use struct mbuf *m variable as if_input argument.
It's a common approach in FreeBSD.
However, the entire function refactorization will be required in the next step.