### PR TITLE
Rnd203-341

### DIFF
--- a/sys/dev/ath/ath_hal/ah.c
+++ b/sys/dev/ath/ath_hal/ah.c
@@ -20,7 +20,6 @@
 
 #include "ah.h"
 #include "ah_internal.h"
-#include "ah_devid.h"
 #include "ah_eeprom.h"			/* for 5ghz fast clock flag */
 
 #include "ar5416/ar5416reg.h"		/* NB: includes ar5212reg.h */
@@ -81,7 +80,7 @@ ath_hal_probe(uint16_t vendorid, uint16_t devid)
  * disable.
  */
 struct ath_hal*
-ath_hal_attach(uint16_t devid, HAL_SOFTC sc,
+ath_hal_attach(uint16_t venid, uint16_t devid, HAL_SOFTC sc,
 	HAL_BUS_TAG st, HAL_BUS_HANDLE sh, uint16_t *eepromdata,
 	HAL_OPS_CONFIG *ah_config,
 	HAL_STATUS *error)
@@ -94,7 +93,7 @@ ath_hal_attach(uint16_t devid, HAL_SOFTC sc,
 		struct ath_hal *ah;
 
 		/* XXX don't have vendorid, assume atheros one works */
-		if (chip->probe(ATHEROS_VENDOR_ID, devid) == AH_NULL)
+		if (chip->probe(venid, devid) == AH_NULL)
 			continue;
 		ah = chip->attach(devid, sc, st, sh, eepromdata, ah_config,
 		    error);
@@ -117,7 +116,7 @@ ath_hal_attach(uint16_t devid, HAL_SOFTC sc,
 		struct ath_hal *ah;
 
 		/* XXX don't have vendorid, assume atheros one works */
-		if (chip->probe(ATHEROS_VENDOR_ID, devid) == AH_NULL)
+		if (chip->probe(venid, devid) == AH_NULL)
 			continue;
 		ah = chip->attach(devid, sc, st, sh, eepromdata, ah_config,
 		    error);

--- a/sys/dev/ath/ath_hal/ah.h
+++ b/sys/dev/ath/ath_hal/ah.h
@@ -1568,8 +1568,8 @@ extern	const char *__ahdecl ath_hal_probe(uint16_t vendorid, uint16_t devid);
  * null (AH_NULL) reference will be returned and a status code will
  * be returned if the status parameter is non-zero.
  */
-extern	struct ath_hal * __ahdecl ath_hal_attach(uint16_t devid, HAL_SOFTC,
-		HAL_BUS_TAG, HAL_BUS_HANDLE, uint16_t *eepromdata,
+extern	struct ath_hal * __ahdecl ath_hal_attach(uint16_t venid, uint16_t devid,
+		HAL_SOFTC, HAL_BUS_TAG, HAL_BUS_HANDLE, uint16_t *eepromdata,
 		HAL_OPS_CONFIG *ah_config, HAL_STATUS* status);
 
 extern	const char *ath_hal_mac_name(struct ath_hal *);

--- a/sys/dev/ath/if_ath.c
+++ b/sys/dev/ath/if_ath.c
@@ -596,7 +596,7 @@ ath_fetch_mac_kenv(struct ath_softc *sc, uint8_t *macaddr)
 	(HAL_MODE_11NG_HT40PLUS | HAL_MODE_11NG_HT40MINUS | \
 	HAL_MODE_11NA_HT40PLUS | HAL_MODE_11NA_HT40MINUS)
 int
-ath_attach(u_int16_t devid, struct ath_softc *sc)
+ath_attach(u_int16_t venid, u_int16_t devid, struct ath_softc *sc)
 {
 	struct ieee80211com *ic = &sc->sc_ic;
 	struct ath_hal *ah = NULL;
@@ -620,7 +620,7 @@ ath_attach(u_int16_t devid, struct ath_softc *sc)
 	bzero(&ah_config, sizeof(ah_config));
 	ath_setup_hal_config(sc, &ah_config);
 
-	ah = ath_hal_attach(devid, sc, sc->sc_st, sc->sc_sh,
+	ah = ath_hal_attach(venid, devid, sc, sc->sc_st, sc->sc_sh,
 	    sc->sc_eepromdata, &ah_config, &status);
 	if (ah == NULL) {
 		device_printf(sc->sc_dev,

--- a/sys/dev/ath/if_ath_pci.c
+++ b/sys/dev/ath/if_ath_pci.c
@@ -63,6 +63,8 @@
 #include <dev/pci/pcivar.h>
 #include <dev/pci/pcireg.h>
 
+#include <dev/ath/ath_hal/ah_devid.h>	
+
 /* For EEPROM firmware */
 #ifdef	ATH_EEPROM_FIRMWARE
 #include <sys/linker.h>
@@ -279,7 +281,7 @@ ath_pci_attach(device_t dev)
 	}
 #endif /* ATH_EEPROM_FIRMWARE */
 
-	error = ath_attach(pci_get_device(dev), sc);
+	error = ath_attach(ATHEROS_VENDOR_ID, pci_get_device(dev), sc);
 	if (error == 0)					/* success */
 		return 0;
 

--- a/sys/dev/ath/if_ath_usb.c
+++ b/sys/dev/ath/if_ath_usb.c
@@ -579,6 +579,8 @@ ath_usb_attachhook(device_t self)
 #if ATHN_API
 	struct ath_ops *ops = &sc->ops;
 #endif
+	struct usb_attach_arg *uaa =  device_get_ivars(self);
+
 	uint32_t val = 104;
 #ifdef notyet
 	struct ieee80211com *ic = &sc->sc_ic;
@@ -648,7 +650,7 @@ ath_usb_attachhook(device_t self)
 	// TODO: MichalP needs proper FreeBSD adaptation because this uses code that is
 	//  stubbed and/or commented
 	#if 0
-	error = ath_attach(sc);
+	error = ath_attach(uaa->info.idVendor, uaa->info.idProduct, sc);
 	if (error != 0) {
 		return;
 	}

--- a/sys/dev/ath/if_athvar.h
+++ b/sys/dev/ath/if_athvar.h
@@ -1043,7 +1043,7 @@ struct ath_softc {
 #define	ATH_TXSTATUS_LOCK_ASSERT(_sc) \
 	mtx_assert(&(_sc)->sc_txcomplock, MA_OWNED)
 
-int	ath_attach(u_int16_t, struct ath_softc *);
+int	ath_attach(u_int16_t, u_int16_t, struct ath_softc *);
 int	ath_detach(struct ath_softc *);
 void	ath_resume(struct ath_softc *);
 void	ath_suspend(struct ath_softc *);


### PR DESCRIPTION
In file ath/ath_hal/ah.c in ath_hal_attach function vendor ID is use as constant for pci devices, so we cannot use other vendor IDs when we connect USB devices.
ATHEROS_VENDOR_ID moved to ath_pci module.