### PR TITLE
RND203-351: Move usb read and write methods to ath_hal_private structure

### DIFF
--- a/sys/dev/ath/ah_osdep.c
+++ b/sys/dev/ath/ah_osdep.c
@@ -278,7 +278,7 @@ ath_hal_reg_write(struct ath_hal *ah, u_int32_t reg, u_int32_t val)
 	bus_space_handle_t h = ah->ah_sh;
 
 	if (ahpriv->ah_isusb) {
-		ath_hal_usbWrite(ah, ah->ah_sc, reg, val);
+		ath_hal_usbWrite(ah, reg, val);
 		return;
 	}
 
@@ -319,7 +319,7 @@ ath_hal_reg_read(struct ath_hal *ah, u_int32_t reg)
 	u_int32_t val;
 
 	if (ahpriv->ah_isusb)
-		return ath_hal_usbRead(ah, ah->ah_sc, reg);
+		return ath_hal_usbRead(ah, reg);
 
 #ifdef	AH_DEBUG
 	/* Debug - complain if we haven't fully waken things up */
@@ -386,7 +386,7 @@ ath_hal_reg_write(struct ath_hal *ah, u_int32_t reg, u_int32_t val)
 	bus_space_handle_t h = ah->ah_sh;
 
 	if (ahpriv->ah_isusb) {
-		ath_hal_usbWrite(ah, ah->ah_sc, reg, val);
+		ath_hal_usbWrite(ah, reg, val);
 		return;
 	}
 
@@ -416,7 +416,7 @@ ath_hal_reg_read(struct ath_hal *ah, u_int32_t reg)
 	u_int32_t val;
 
 	if (ahpriv->ah_isusb)
-		return ath_hal_usbRead(ah, ah->ah_sc, reg);
+		return ath_hal_usbRead(ah, reg);
 
 #ifdef	AH_DEBUG
 	/* Debug - complain if we haven't fully waken things up */

--- a/sys/dev/ath/ah_osdep.c
+++ b/sys/dev/ath/ah_osdep.c
@@ -278,7 +278,7 @@ ath_hal_reg_write(struct ath_hal *ah, u_int32_t reg, u_int32_t val)
 	bus_space_handle_t h = ah->ah_sh;
 
 	if (ahpriv->ah_isusb) {
-		ath_usb_write(ah->ah_sc, reg, val);
+		ath_hal_usbWrite(ah, ah->ah_sc, reg, val);
 		return;
 	}
 
@@ -318,10 +318,8 @@ ath_hal_reg_read(struct ath_hal *ah, u_int32_t reg)
 	bus_space_handle_t h = ah->ah_sh;
 	u_int32_t val;
 
-	if (ahpriv->ah_isusb) {
-		val = ath_usb_read(ah->ah_sc, reg);
-		return val;
-	}
+	if (ahpriv->ah_isusb)
+		return ath_hal_usbRead(ah, ah->ah_sc, reg);
 
 #ifdef	AH_DEBUG
 	/* Debug - complain if we haven't fully waken things up */
@@ -388,7 +386,7 @@ ath_hal_reg_write(struct ath_hal *ah, u_int32_t reg, u_int32_t val)
 	bus_space_handle_t h = ah->ah_sh;
 
 	if (ahpriv->ah_isusb) {
-		ath_usb_write(ah->ah_sc, reg, val);
+		ath_hal_usbWrite(ah, ah->ah_sc, reg, val);
 		return;
 	}
 
@@ -417,10 +415,8 @@ ath_hal_reg_read(struct ath_hal *ah, u_int32_t reg)
 	bus_space_handle_t h = ah->ah_sh;
 	u_int32_t val;
 
-	if (ahpriv->ah_isusb) {
-		val = ath_usb_read(ah->ah_sc, reg);
-		return val;
-	}
+	if (ahpriv->ah_isusb)
+		return ath_hal_usbRead(ah, ah->ah_sc, reg);
 
 #ifdef	AH_DEBUG
 	/* Debug - complain if we haven't fully waken things up */

--- a/sys/dev/ath/ah_osdep_ar5416.c
+++ b/sys/dev/ath/ah_osdep_ar5416.c
@@ -100,3 +100,4 @@ DEV_MODULE(ath_hal_ar5416, ath_hal_ar5416_modevent, NULL);
 MODULE_VERSION(ath_hal_ar5416, 1);
 MODULE_DEPEND(ath_hal_ar5416, ath_hal, 1, 1, 1);
 MODULE_DEPEND(ath_hal_ar5416, ath_hal_ar5212, 1, 1, 1);
+MODULE_DEPEND(ath_hal_ar5416, if_ath_usb, 1, 1, 1);

--- a/sys/dev/ath/ath_hal/ah_internal.h
+++ b/sys/dev/ath/ath_hal/ah_internal.h
@@ -380,6 +380,8 @@ struct ath_hal_private {
 	HAL_BOOL	(*ah_eepromDiag)(struct ath_hal *, int request,
 			    const void *args, uint32_t argsize,
 			    void **result, uint32_t *resultsize);
+	uint32_t	(*ah_usb_read)(void *, uint32_t);
+	void 		(*ah_usb_write)(void *, uint32_t, uint32_t);
 
 	/*
 	 * Device revision information.
@@ -492,7 +494,10 @@ struct ath_hal_private {
 	AH_PRIVATE(_ah)->ah_getSpurChan(_ah, _ix, _is2G)
 #define	ath_hal_eepromDiag(_ah, _request, _a, _asize, _r, _rsize) \
 	AH_PRIVATE(_ah)->ah_eepromDiag(_ah, _request, _a, _asize,  _r, _rsize)
-
+#define ath_hal_usbRead(_ah, _sc, _addr) \
+	AH_PRIVATE(_ah)->ah_usb_read(_sc, _addr)
+#define ath_hal_usbWrite(_ah, _sc, _addr, _val) \
+	AH_PRIVATE(_ah)->ah_usb_write(_sc, _addr, _val)	
 #ifndef _NET_IF_IEEE80211_H_
 /*
  * Stuff that would naturally come from _ieee80211.h

--- a/sys/dev/ath/ath_hal/ah_internal.h
+++ b/sys/dev/ath/ath_hal/ah_internal.h
@@ -29,6 +29,7 @@
 
 #include <net80211/_ieee80211.h>
 #include <sys/queue.h>			/* XXX for reasons */
+#include "ah_osdep.h"
 
 #ifndef NBBY
 #define	NBBY	8			/* number of bits/byte */
@@ -380,8 +381,8 @@ struct ath_hal_private {
 	HAL_BOOL	(*ah_eepromDiag)(struct ath_hal *, int request,
 			    const void *args, uint32_t argsize,
 			    void **result, uint32_t *resultsize);
-	uint32_t	(*ah_usb_read)(void *, uint32_t);
-	void 		(*ah_usb_write)(void *, uint32_t, uint32_t);
+	uint32_t	(*ah_usb_read)(HAL_SOFTC *, uint32_t);
+	void 		(*ah_usb_write)(HAL_SOFTC *, uint32_t, uint32_t);
 
 	/*
 	 * Device revision information.
@@ -494,10 +495,10 @@ struct ath_hal_private {
 	AH_PRIVATE(_ah)->ah_getSpurChan(_ah, _ix, _is2G)
 #define	ath_hal_eepromDiag(_ah, _request, _a, _asize, _r, _rsize) \
 	AH_PRIVATE(_ah)->ah_eepromDiag(_ah, _request, _a, _asize,  _r, _rsize)
-#define ath_hal_usbRead(_ah, _sc, _addr) \
-	AH_PRIVATE(_ah)->ah_usb_read(_sc, _addr)
-#define ath_hal_usbWrite(_ah, _sc, _addr, _val) \
-	AH_PRIVATE(_ah)->ah_usb_write(_sc, _addr, _val)	
+#define ath_hal_usbRead(_ah, _addr) \
+	AH_PRIVATE(_ah)->ah_usb_read(_ah->ah_sc, _addr)
+#define ath_hal_usbWrite(_ah, _addr, _val) \
+	AH_PRIVATE(_ah)->ah_usb_write(_ah->ah_sc, _addr, _val)	
 #ifndef _NET_IF_IEEE80211_H_
 /*
  * Stuff that would naturally come from _ieee80211.h

--- a/sys/dev/ath/ath_hal/ar9002/ar9271_attach.c
+++ b/sys/dev/ath/ath_hal/ar9002/ar9271_attach.c
@@ -40,6 +40,7 @@
 #include "ar9002/ar9271_diversity.h"
 
 #include "if_ath_usb_devid.h"
+#include "if_ath_usb.h"
 
 static const HAL_PERCAL_DATA ar9280_iq_cal = {		/* single sample */
 	.calName = "IQ", .calType = IQ_MISMATCH_CAL,
@@ -201,6 +202,10 @@ ar9271Attach(uint16_t devid, HAL_SOFTC sc,
 
 	ahp->ah_maxTxTrigLev		= MAX_TX_FIFO_THRESHOLD >> 1;
 
+	AH_PRIVATE(ah)->ah_isusb	= TRUE;
+	AH_PRIVATE(ah)->ah_usb_read	= (void *)ath_usb_read;
+	AH_PRIVATE(ah)->ah_usb_write	= (void *)ath_usb_write;
+
 	if (!ar5416SetResetReg(ah, HAL_RESET_POWER_ON)) {
 		/* reset chip */
 		HALDEBUG(ah, HAL_DEBUG_ANY, "%s: couldn't reset chip\n",
@@ -226,7 +231,6 @@ ar9271Attach(uint16_t devid, HAL_SOFTC sc,
 	    (val & AR_XSREV_VERSION) >> AR_XSREV_TYPE_S;
 	AH_PRIVATE(ah)->ah_macRev = MS(val, AR_XSREV_REVISION);
 	AH_PRIVATE(ah)->ah_ispcie = (val & AR_XSREV_TYPE_HOST_MODE) == 0;
-	AH_PRIVATE(ah)->ah_isusb = TRUE;
 
 	/* setup common ini data; rf backends handle remainder */
 	if (AR_SREV_KITE_12_OR_LATER(ah)) {
@@ -446,7 +450,6 @@ ar9271FillCapabilityInfo(struct ath_hal *ah)
 	/* Wake-on-Wireless */
 	pCap->halWowSupport = AH_FALSE;
 	pCap->halWowMatchPatternExact = AH_FALSE;
-	pCap->halWowMatchPatternDword = AH_FALSE;
 
 	/* AR9271 supports one transmit and one receive traffic stream */
 	pCap->halTxStreams = 1;


### PR DESCRIPTION
I don't like the `(void *)` casting I used in functions assignment, but I couldn't use the original `struct ath_softc *sc` as read and write functions parameters because of the messed up headers.
NOTE: because of the new module dependency I will move the loading of `if_ath_usb.ko` before `ath_hal_ar5416.ko`.
I also fixed missed `halWowMatchPatternDword` build error from last commit.