### PR TITLE
RND211-39: Remove NATHN_USB macro, implement athn_usb_tx excluding CCMP encryption

### DIFF
--- a/sys/dev/athn/ar9285.c
+++ b/sys/dev/athn/ar9285.c
@@ -119,21 +119,19 @@ ar9285_attach(struct athn_softc *sc)
 	sc->ops.set_synth = ar9280_set_synth;
 	sc->ops.spur_mitigate = ar9280_spur_mitigate;
 	sc->ops.get_spur_chans = ar9285_get_spur_chans;
-#if NATHN_USB > 0
+
 	if (AR_SREV_9271(sc)) {
 		sc->cca_min_2g = AR9271_PHY_CCA_MIN_GOOD_VAL_2GHZ;
 		sc->cca_max_2g = AR9271_PHY_CCA_MAX_GOOD_VAL_2GHZ;
 	} else
-#endif
 	{
 		sc->cca_min_2g = AR9285_PHY_CCA_MIN_GOOD_VAL_2GHZ;
 		sc->cca_max_2g = AR9285_PHY_CCA_MAX_GOOD_VAL_2GHZ;
 	}
-#if NATHN_USB > 0
 	if (AR_SREV_9271(sc))
 		sc->ini = &ar9271_ini;
 	else
-#endif
+
 		sc->ini = &ar9285_1_2_ini;
 	sc->serdes = &ar9280_2_0_serdes;
 
@@ -149,14 +147,13 @@ ar9285_setup(struct athn_softc *sc)
 	/* Select initialization values based on ROM. */
 	type = eep->baseEepHeader.txGainType;
 	DPRINTF(("Tx gain type=0x%x\n", type));
-#if NATHN_USB > 0
+
 	if (AR_SREV_9271(sc)) {
 		if (type == AR_EEP_TXGAIN_HIGH_POWER)
 			sc->tx_gain = &ar9271_tx_gain_high_power;
 		else
 			sc->tx_gain = &ar9271_tx_gain;
 	} else
-#endif	/* NATHN_USB */
 	if ((AR_READ(sc, AR_AN_SYNTH9) & 0x7) == 0x1) {	/* XE rev. */
 		if (type == AR_EEP_TXGAIN_HIGH_POWER)
 			sc->tx_gain = &ar9285_2_0_tx_gain_high_power;
@@ -324,7 +321,6 @@ ar9285_init_from_rom(struct athn_softc *sc, struct ieee80211_channel *c,
 		db2[0] = modal->db1_01;
 		db2[1] = db2[2] = db2[3] = db2[4] = db2[0];
 	}
-#if NATHN_USB > 0
 	if (AR_SREV_9271(sc)) {
 		reg = AR_READ(sc, AR9285_AN_RF2G3);
 		reg = RW(reg, AR9271_AN_RF2G3_OB_CCK, ob [0]);
@@ -340,7 +336,6 @@ ar9285_init_from_rom(struct athn_softc *sc, struct ieee80211_channel *c,
 		AR_WRITE_BARRIER(sc);
 		DELAY(100);
 	} else
-#endif	/* ATHN_USB */
 	{
 		reg = AR_READ(sc, AR9285_AN_RF2G3);
 		reg = RW(reg, AR9285_AN_RF2G3_OB_0,  ob [0]);
@@ -514,7 +509,6 @@ ar9285_pa_calib(struct athn_softc *sc)
 void
 ar9271_pa_calib(struct athn_softc *sc)
 {
-#if NATHN_USB > 0
 	/* List of registers that need to be saved/restored. */
 	static const uint16_t regs[] = {
 		AR9285_AN_TOP3,
@@ -590,7 +584,6 @@ ar9271_pa_calib(struct athn_softc *sc)
 	/* Restore compensation capacitor value. */
 	AR_WRITE(sc, AR9285_AN_RF2G3, rf2g3_svg);
 	AR_WRITE_BARRIER(sc);
-#endif	/* NATHN_USB */
 }
 
 /*
@@ -644,7 +637,6 @@ ar9285_cl_cal(struct athn_softc *sc, struct ieee80211_channel *c,
 void
 ar9271_load_ani(struct athn_softc *sc)
 {
-#if NATHN_USB > 0
 	/* Write ANI registers. */
 	AR_WRITE(sc, AR_PHY_DESIRED_SZ, 0x6d4000e2);
 	AR_WRITE(sc, AR_PHY_AGC_CTL1,   0x3139605e);
@@ -655,7 +647,6 @@ ar9271_load_ani(struct athn_softc *sc)
 	AR_WRITE(sc, AR_PHY_TIMING5,    0xd00a8007);
 	AR_WRITE(sc, AR_PHY_SFCORR_EXT, 0x05eea6d4);
 	AR_WRITE_BARRIER(sc);
-#endif	/* NATHN_USB */
 }
 
 int

--- a/sys/dev/athn/headers/ar9285reg.h
+++ b/sys/dev/athn/headers/ar9285reg.h
@@ -497,7 +497,6 @@ static const struct athn_ini ar9285_1_2_ini = {
 	ar9285_1_2_cm_vals
 };
 
-#if NATHN_USB > 0
 /*
  * AR9271 programming.
  */
@@ -840,7 +839,6 @@ static const struct athn_ini ar9271_ini = {
 	ar9271_cm_regs,
 	ar9271_cm_vals
 };
-#endif	/* NATHN_USB */
 
 /*
  * AR9285 1.2 Tx gains.
@@ -931,7 +929,6 @@ static const struct athn_gain ar9285_2_0_tx_gain_high_power = {
 	ar9285_2_0_tx_gain_high_power_vals_2g
 };
 
-#if NATHN_USB > 0
 /*
  * AR9271 Tx gains.
  */
@@ -978,4 +975,3 @@ static const struct athn_gain ar9271_tx_gain_high_power = {
 	NULL,	/* 2GHz only. */
 	ar9271_tx_gain_high_power_vals_2g
 };
-#endif	/* NATHN_USB */

--- a/sys/dev/athn/headers/if_athn_usb.h
+++ b/sys/dev/athn/headers/if_athn_usb.h
@@ -415,6 +415,7 @@ struct athn_usb_rx_data {
 	char			*buf;
 };
 
+// TODO: to be removed. Replaced by athn_usb_data
 #if OpenBSD_ONLY
 struct athn_usb_tx_data {
 	struct athn_usb_softc		*sc;


### PR DESCRIPTION
You can compare 2 last commits to see difference between original OpenBSD and modified implementation